### PR TITLE
Enforce timeout for user hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN echo "HostKey /git/.ssh/host_keys/ssh_host_rsa_key" >> /etc/ssh/sshd_config 
     echo "HostKey /git/.ssh/host_keys/ssh_host_ecdsa_key" >> /etc/ssh/sshd_config && \
     echo "HostKey /git/.ssh/host_keys/ssh_host_ed25519_key" >> /etc/ssh/sshd_config && \
     echo "PasswordAuthentication no" >> /etc/ssh/sshd_config && \
+    echo "ClientAliveInterval 30" >> /etc/ssh/sshd_config && \
+    echo "ClientAliveCountMax 3" >> /etc/ssh/sshd_config && \
     echo "UsePrivilegeSeparation no" >> /etc/ssh/sshd_config
 
 RUN mkdir -p /backup_volume 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN chown -R git:git /backup_volume
 ENV PORT=2222
 ENV PATH=/git/bin:/git/git-shell-commands:/opt/git-deploy/bin:$PATH
 
+ENV DEPLOY_TIMEOUT_TERM=600s
+ENV DEPLOY_TIMEOUT_KILL=620s
+
 RUN echo "Git-Deploy Shell" > /etc/motd
 
 EXPOSE $PORT

--- a/base-hooks/pre-receive
+++ b/base-hooks/pre-receive
@@ -32,7 +32,7 @@ while read oldrev newrev refname; do
 
 	if [ -f "$hook_dir/pre-receive" ]; then
 		( flock -nx 201 || exit 1
-			echo $oldrev $newrev $refname | timeout -k 620s 600s bash $hook_dir/pre-receive
+			echo $oldrev $newrev $refname | timeout -k ${DEPLOY_TIMEOUT_KILL} ${DEPLOY_TIMEOUT_TERM} bash $hook_dir/pre-receive
 		) 201>pre_receive_lock
 	fi
 

--- a/base-hooks/pre-receive
+++ b/base-hooks/pre-receive
@@ -32,7 +32,7 @@ while read oldrev newrev refname; do
 
 	if [ -f "$hook_dir/pre-receive" ]; then
 		( flock -nx 201 || exit 1
-			echo $oldrev $newrev $refname | bash $hook_dir/pre-receive 
+			echo $oldrev $newrev $refname | timeout -k 620s 600s bash $hook_dir/pre-receive
 		) 201>pre_receive_lock
 	fi
 

--- a/test/test-hooks/pre-receive
+++ b/test/test-hooks/pre-receive
@@ -9,6 +9,10 @@ while read oldrev newrev refname; do
 		FILES=$(git diff --name-only $oldrev..$newrev)
 	fi
 
+	# Launch an ssh agent to be nasty
+	eval $(ssh-agent -s) 2>&1 > /dev/null
+	trap "kill ${SSH_AGENT_PID}" EXIT
+
 	for file in $FILES; do
 		[ $file != 'badfile' ] || exit 1
 		if [ "$file" == 'slowfile' ]; then
@@ -16,6 +20,11 @@ while read oldrev newrev refname; do
 			sleep 5
 			# pick up breadcrumb if it exists; fail if it was stolen (by a concurrent hook)
 			[ -f breadcrumb ] && rm -f breadcrumb || exit 1
+		fi
+		if [ "$file" == 'stallfile' ]; then
+			while [ true ]; do
+				sleep 5
+			done
 		fi
 	done
 done

--- a/test/test.bats
+++ b/test/test.bats
@@ -217,6 +217,25 @@ teardown(){
 	[ "$status" -eq 0 ]
 }
 
+@test "Sandbox locks expire" {
+	run_container
+	ssh_command "mkrepo testhookrepo"
+	ssh_command "mkrepo testrepo"
+	clone_repo testhookrepo
+	clone_repo testrepo
+	destroy_container
+	run_container /git/testhookrepo
+	push_hook testhookrepo master pre-receive
+
+	# The hook never finishes, but push times out
+	run push_test_commit testrepo stallfile
+	[ "$status" -eq 1 ]
+
+	# Subsequent pushes are not blocked
+	run push_test_commit testrepo goodfile
+	[ "$status" -eq 0 ]
+}
+
 @test "Generate encryption key" {
 	run_container
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -28,6 +28,8 @@ run_container(){
 		-e DEST=file:///backup_volume \
 		-e PASSPHRASE=a_test_passphrase \
 		-e HOOK_REPO=$hook_repo \
+		-e DEPLOY_TIMEOUT_TERM=10s \
+		-e DEPLOY_TIMEOUT_KILL=12s \
 		--volumes-from test-git-deploy-data \
 		-v /dev/urandom:/dev/random \
 		-p 2222:2222 \


### PR DESCRIPTION
Have sshd ping clients that may have disconnected.

Launch an ssh-agent in a hook to verify it can be used+cleaned up
without leaking/holding lock.