### PR TITLE
PBL-24910: log all the things

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,9 @@ RUN pip install awscli boto virtualenv && \
 RUN useradd -m -d /git -s /usr/bin/git-shell git
 RUN usermod -p $(od -An -N20 -v -w20 -tx1 /dev/urandom | tr -d ' ') git
 
-RUN mkdir -p /var/run/sshd
-RUN echo "HostKey /git/.ssh/host_keys/ssh_host_rsa_key" >> /etc/ssh/sshd_config && \
-    echo "HostKey /git/.ssh/host_keys/ssh_host_dsa_key" >> /etc/ssh/sshd_config && \
-    echo "HostKey /git/.ssh/host_keys/ssh_host_ecdsa_key" >> /etc/ssh/sshd_config && \
-    echo "HostKey /git/.ssh/host_keys/ssh_host_ed25519_key" >> /etc/ssh/sshd_config && \
-    echo "PasswordAuthentication no" >> /etc/ssh/sshd_config && \
-    echo "ClientAliveInterval 30" >> /etc/ssh/sshd_config && \
-    echo "ClientAliveCountMax 3" >> /etc/ssh/sshd_config && \
-    echo "UsePrivilegeSeparation no" >> /etc/ssh/sshd_config
+RUN mkdir -p /var/run/sshd /var/log/git-deploy && \
+    chown git /var/run/sshd /var/log/git-deploy
+ADD sshd_config /etc/ssh/sshd_config
 
 RUN mkdir -p /backup_volume 
 RUN chown -R git:git /backup_volume

--- a/base-hooks/post-receive
+++ b/base-hooks/post-receive
@@ -1,9 +1,12 @@
 #!/bin/bash
+
 source ~/.profile
+set -o pipefail
+
 if [ ! -z "$HOOK_REPO" ]; then
 	hook_dir="/git/hooks"
 else
 	hook_dir="../hooks"
 fi
-[ ! -f "$hook_dir/post-receive" ] || bash $hook_dir/post-receive
+[ ! -f "$hook_dir/post-receive" ] || bash $hook_dir/post-receive | tee /var/log/git-deploy/hooks.log
 backup

--- a/base-hooks/pre-receive
+++ b/base-hooks/pre-receive
@@ -1,5 +1,8 @@
 #!/bin/bash
+
 source ~/.profile
+set -o pipefail
+
 unset GIT_DIR
 cd ..
 env -i git reset --hard
@@ -32,7 +35,9 @@ while read oldrev newrev refname; do
 
 	if [ -f "$hook_dir/pre-receive" ]; then
 		( flock -nx 201 || exit 1
-			echo $oldrev $newrev $refname | timeout -k ${DEPLOY_TIMEOUT_KILL} ${DEPLOY_TIMEOUT_TERM} bash $hook_dir/pre-receive
+			echo $oldrev $newrev $refname \
+				| timeout -k ${DEPLOY_TIMEOUT_KILL} ${DEPLOY_TIMEOUT_TERM} bash $hook_dir/pre-receive \
+				| tee /var/log/git-deploy/hooks.log
 		) 201>pre_receive_lock
 	fi
 

--- a/base-hooks/update
+++ b/base-hooks/update
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ~/.profile
+set -o pipefail
 
 if [ ! -z "$HOOK_REPO" ]; then
 	hook_dir="/git/hooks"
@@ -8,4 +9,4 @@ else
 	hook_dir="../hooks"
 fi
 
-[ ! -f "$hook_dir/update" ] || bash $hook_dir/update $@
+[ ! -f "$hook_dir/update" ] || bash $hook_dir/update $@ | tee /var/log/git-deploy/hooks.log

--- a/init.sh
+++ b/init.sh
@@ -20,8 +20,12 @@ fi
 
 rm /git/.profile
 for LINE in `env`; do
-    echo "export $LINE" >> ~/.profile;
+    echo "export $LINE" >> /git/.profile;
 done
 
+# Run tail until parent pid (bash) dies, reading from fifo
+mkfifo /var/log/git-deploy/hooks.log
+tail --pid $$ -F /var/log/git-deploy/hooks.log &
+
 echo "Starting Git-Deploy on port $PORT"
-/usr/sbin/sshd -D -p $PORT
+/usr/sbin/sshd -D -e -p $PORT

--- a/sshd_config
+++ b/sshd_config
@@ -1,0 +1,39 @@
+Protocol 2
+
+KeyRegenerationInterval 3600
+ServerKeyBits 1024
+
+SyslogFacility AUTH
+LogLevel INFO
+
+LoginGraceTime 120
+PermitRootLogin no
+StrictModes yes
+
+RSAAuthentication yes
+PubkeyAuthentication yes
+IgnoreRhosts yes
+RhostsRSAAuthentication no
+HostbasedAuthentication no
+PermitEmptyPasswords no
+ChallengeResponseAuthentication no
+
+X11Forwarding no
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+
+AcceptEnv LANG LC_*
+
+UsePAM yes
+HostKey /git/.ssh/host_keys/ssh_host_rsa_key
+HostKey /git/.ssh/host_keys/ssh_host_dsa_key
+HostKey /git/.ssh/host_keys/ssh_host_ecdsa_key
+HostKey /git/.ssh/host_keys/ssh_host_ed25519_key
+PasswordAuthentication no
+ClientAliveInterval 30
+ClientAliveCountMax 3
+UsePrivilegeSeparation no
+
+PidFile /var/run/sshd/sshd.pid

--- a/test/test-hooks/pre-receive
+++ b/test/test-hooks/pre-receive
@@ -14,7 +14,10 @@ while read oldrev newrev refname; do
 	trap "kill ${SSH_AGENT_PID}" EXIT
 
 	for file in $FILES; do
-		[ $file != 'badfile' ] || exit 1
+		if [ "$file" == 'badfile' ]; then
+			echo "Rejecting badfile"
+			exit 1
+		fi
 		if [ "$file" == 'slowfile' ]; then
 			touch breadcrumb
 			sleep 5


### PR DESCRIPTION
Rsyslog is introduced as a necessary evil to capture
sshd's output: auth success/failure.
Supervisord is introduced to run rsyslog and sshd simultaneously.

Hooks feed their output into syslog, which serializes everything to
stdout.

A mostly-defaulted sshd_config is introduced to silence sshd warnings:
the default HostKey entries spam every connection attempt.