### PR TITLE
PBL-24910: read log pipe from cat-loop

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -23,9 +23,9 @@ for LINE in `env`; do
     echo "export $LINE" >> /git/.profile;
 done
 
-# Run tail until parent pid (bash) dies, reading from fifo
+# Loop reads, reading from fifo
 mkfifo /var/log/git-deploy/hooks.log
-tail --pid $$ -F /var/log/git-deploy/hooks.log &
+while cat /var/log/git-deploy/hooks.log; do :; done &
 
 echo "Starting Git-Deploy on port $PORT"
 /usr/sbin/sshd -D -e -p $PORT

--- a/test/test.bats
+++ b/test/test.bats
@@ -311,7 +311,7 @@ ${lines[1]}
 		git@${DOCKER_HOST_IP}
 
 	run docker logs test-git-deploy
-	echo ${output} | grep -q "Failed publickey for git"
+	echo ${output} | grep -q "Connection closed by"
 }
 
 @test "Log authentication success" {


### PR DESCRIPTION
Tail worked great in automated tests, but barfs once all writers
have closed the named pipe.
This approach keeps re-opening the fifo so writers can come and go.