### PR TITLE
Make output capture optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ENV PATH=/git/bin:/git/git-shell-commands:/opt/git-deploy/bin:$PATH
 
 ENV DEPLOY_TIMEOUT_TERM=600s
 ENV DEPLOY_TIMEOUT_KILL=620s
+ENV CAPTURE_OUTPUT=true
 
 RUN echo "Git-Deploy Shell" > /etc/motd
 

--- a/base-hooks/pre-receive
+++ b/base-hooks/pre-receive
@@ -39,9 +39,15 @@ while read oldrev newrev refname; do
 				echo "Unable to acquire local deploy lock, another git push is in progress"
 				exit 1
 			fi
-			echo $oldrev $newrev $refname \
-				| timeout -k ${DEPLOY_TIMEOUT_KILL} ${DEPLOY_TIMEOUT_TERM} bash $hook_dir/pre-receive 2>&1 \
-				| tee /var/log/git-deploy/hooks.log
+
+			if [ "${CAPTURE_OUTPUT}" == "true" ]; then
+				echo $oldrev $newrev $refname \
+					| timeout -k ${DEPLOY_TIMEOUT_KILL} ${DEPLOY_TIMEOUT_TERM} bash $hook_dir/pre-receive 2>&1 \
+					| tee /var/log/git-deploy/hooks.log
+			else
+				echo $oldrev $newrev $refname \
+					| timeout -k ${DEPLOY_TIMEOUT_KILL} ${DEPLOY_TIMEOUT_TERM} bash $hook_dir/pre-receive
+			fi
 		) 201>pre_receive_lock
 	fi
 


### PR DESCRIPTION
This can be done globally (docker env) or per-repo (config.env).

This enables hooks with logging frameworks to:
* write all messages directly into named pipe (FileAppender)
* forward >= WARN messages directly to the caller via stdout/stderr
(ConsoleAppender)
Workarounds to de-dupe events (i.e. don't write >= WARN to file) drop
messages when the client disconnects (and stderr is closed).

Since plain-old-hooks be smart enough to tee their own logging streams,
continue capturing stdout/stderr unless explicitly disabled.