### PR TITLE
Add a post-generate-key hook

### DIFF
--- a/base-hooks/post-generate-key
+++ b/base-hooks/post-generate-key
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source ~/.profile
+set -o pipefail
+
+if [ ! -z "$HOOK_REPO" ]; then
+	hook_dir="/git/hooks"
+else
+	hook_dir="../hooks"
+fi
+[ ! -f "$hook_dir/post-generate-key" ] || bash $hook_dir/post-generate-key | tee /var/log/git-deploy/hooks.log
+backup

--- a/bin/genkey
+++ b/bin/genkey
@@ -49,3 +49,5 @@ Expire-Date: 0
 
 ensure_key git-deploy sign
 ensure_key ${KEY_NAME} encrypt true
+
+git-shell-commands/post-generate-key

--- a/test/test-hooks/post-generate-key
+++ b/test/test-hooks/post-generate-key
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo post-generate-key success


### PR DESCRIPTION
This allows external hooks to execute commands after a key has been generated exposing the following options:
  - clean up the key (security!)
  - store the key somewhere else (external secured storage)