### PR TITLE
Pass extra args

### DIFF
--- a/bin/genkey
+++ b/bin/genkey
@@ -6,7 +6,7 @@ KEY_SIZE=4096
 
 KEY_NAME=$1
 if [ -z "${KEY_NAME}" ]; then
-	echo "Usage: $0 key_name"
+	echo "Usage: $0 key_name [optional extra args]"
 	exit 1
 fi
 
@@ -50,4 +50,4 @@ Expire-Date: 0
 ensure_key git-deploy sign
 ensure_key ${KEY_NAME} encrypt true
 
-git-shell-hooks/post-generate-key ${KEY_NAME}
+git-shell-hooks/post-generate-key $@


### PR DESCRIPTION
Allow `genkey key_name [optional extra args]` so we can pass `genkey key_name [environment]` for our use case.

@lrvick 