### PR TITLE
Use fetch and reset over pull

### DIFF
--- a/base-hooks/pre-receive
+++ b/base-hooks/pre-receive
@@ -22,13 +22,19 @@ while read oldrev newrev refname; do
 			mkdir -p $hook_dir
 			git clone $HOOK_REPO $hook_dir
 		fi
+		git \
+			--git-dir="$hook_dir/.git" \
+			--work-tree="$hook_dir" \
+			fetch --all
 		if [ ! -z "$HOOK_REPO_REF" ]; then
 			git \
 				--git-dir="$hook_dir/.git" \
 				--work-tree="$hook_dir" \
-				checkout $HOOK_REPO_REF
+				reset --hard origin/$HOOK_REPO_REF
+		else
+			git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" pull
 		fi
-		git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" pull
+		
 		if [ "$HOOK_REPO_VERIFY" = true ]; then
 			sign_status=$( git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" log --show-signature --pretty="%G?" -1 HEAD | tail -n1 )
 			if [ "$sign_status" != "G" ]; then


### PR DESCRIPTION
There would sometimes be a path where git is asking to merge on the `git-deploy` instance, because we're entering the `pull` state. Using `fetch` + `reset` should save us from this bug in the future.

Fixes #28 

@pebble/webops 