### PR TITLE
WEBOPS-424: git-shell "run" to delegate to scripts in hooks repo

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -10,13 +10,18 @@ if [ ! -z "$HOOK_REPO" ]; then
 		mkdir -p $hook_dir
 		git clone $HOOK_REPO $hook_dir
 	fi
+	git \
+		--git-dir="$hook_dir/.git" \
+		--work-tree="$hook_dir" \
+		fetch --all
 	if [ ! -z "$HOOK_REPO_REF" ]; then
 		git \
 			--git-dir="$hook_dir/.git" \
 			--work-tree="$hook_dir" \
-			checkout $HOOK_REPO_REF
+			reset --hard origin/$HOOK_REPO_REF
+	else
+		git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" pull
 	fi
-	git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" pull
 	if [ "$HOOK_REPO_VERIFY" = true ]; then
 		sign_status=$( git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" log --show-signature --pretty="%G?" -1 HEAD | tail -n1 )
 		if [ "$sign_status" != "G" ]; then

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+source ~/.profile
+
+CMD=$1
+
+if [ ! -z "$HOOK_REPO" ]; then
+	hook_dir="/git/hooks"
+	if [ ! -d "$hook_dir" ]; then
+		mkdir -p $hook_dir
+		git clone $HOOK_REPO $hook_dir
+	fi
+	if [ ! -z "$HOOK_REPO_REF" ]; then
+		git \
+			--git-dir="$hook_dir/.git" \
+			--work-tree="$hook_dir" \
+			checkout $HOOK_REPO_REF
+	fi
+	git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" pull
+	if [ "$HOOK_REPO_VERIFY" = true ]; then
+		sign_status=$( git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" log --show-signature --pretty="%G?" -1 HEAD | tail -n1 )
+		if [ "$sign_status" != "G" ]; then
+			echo "Latest commit in $HOOK_REPO is not signed by a known key"
+			exit 1
+		fi
+	fi
+
+else
+	hook_dir="hooks"
+fi
+
+if [ -x "${hook_dir}/bin/${CMD}" ]; then
+	shift
+	${hook_dir}/bin/${CMD} $*
+else
+	exit 1
+fi

--- a/test/test-hooks/bin/hello
+++ b/test/test-hooks/bin/hello
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Hello $1"
+date

--- a/test/test.bats
+++ b/test/test.bats
@@ -422,3 +422,27 @@ ${lines[1]}
 		git@${DOCKER_HOST_IP}
 	[ $status -eq 0 ]
 }
+
+@test "Run script from hook dir" {
+	run_container
+	ssh_command "mkrepo testhookrepo"
+	ssh_command "mkrepo testrepo"
+	clone_repo testhookrepo
+	clone_repo testrepo
+	destroy_container
+	run_container /git/testhookrepo
+	push_hook testhookrepo master bin/hello
+
+	run ssh_command "run hello World"
+	[ $status -eq 0 ]
+	echo $output
+	echo ${output} | grep -q "Hello World"
+}
+
+@test "Run script from hook dir - not found" {
+	run_container
+	ssh_command "mkrepo testrepo"
+
+	run ssh_command "run hello World"
+	[ $status -eq 1 ]
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -168,7 +168,12 @@ push_hook() {
 	local repo_folder="/tmp/git-deploy-test/$repo/"
 	if [ -d "$repo_folder" ]; then
 		mkdir -p $repo_folder/$hook_folder
-		cp $PWD/test/test-hooks/$hook_name $repo_folder/$hook_file
+		hook_source=$PWD/test/test-hooks/$hook_file
+		if [ -f $PWD/test/test-hooks/$hook_name ]; then
+			hook_source=$PWD/test/test-hooks/$hook_name
+		fi
+
+		cp $hook_source $repo_folder/$hook_file
 		git --git-dir=$repo_folder/.git --work-tree=$repo_folder checkout -B $branch
 		git --git-dir=$repo_folder/.git --work-tree=$repo_folder add .
 		if [[ ! -z "$sign_key" ]]; then


### PR DESCRIPTION
This lets hooks define their own helper functions (which can share
code/libraries with the hooks themselves).