### PR TITLE
WEBOPS-424: 'run' command requires environment

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -2,7 +2,14 @@
 
 source ~/.profile
 
-CMD=$1
+export ENVIRONMENT=$1
+CMD=$2
+
+cd /git/${ENVIRONMENT}
+git ls-tree --name-only -r master | grep -Fx config.env 2>&1 > /dev/null
+if [ $? -eq 0 ]; then
+	source <(git cat-file blob master:config.env)
+fi
 
 if [ ! -z "$HOOK_REPO" ]; then
 	hook_dir="/git/hooks"
@@ -29,13 +36,12 @@ if [ ! -z "$HOOK_REPO" ]; then
 			exit 1
 		fi
 	fi
-
 else
 	hook_dir="hooks"
 fi
 
 if [ -x "${hook_dir}/bin/${CMD}" ]; then
-	shift
+	shift 2
 	${hook_dir}/bin/${CMD} $*
 else
 	exit 1

--- a/test/test-hooks/bin/hello
+++ b/test/test-hooks/bin/hello
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 echo "Hello $1"
+echo "From ${ENVIRONMENT}"
 date

--- a/test/test-hooks/config.env
+++ b/test/test-hooks/config.env
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export HOOK_REPO=/git/testhookrepo

--- a/test/test.bats
+++ b/test/test.bats
@@ -433,16 +433,31 @@ ${lines[1]}
 	run_container /git/testhookrepo
 	push_hook testhookrepo master bin/hello
 
-	run ssh_command "run hello World"
+	run ssh_command "run testrepo hello World"
 	[ $status -eq 0 ]
-	echo $output
 	echo ${output} | grep -q "Hello World"
 }
+
+@test "Run script from hook dir - config.env" {
+	run_container
+	ssh_command "mkrepo testhookrepo"
+	ssh_command "mkrepo testrepo"
+	clone_repo testhookrepo
+	clone_repo testrepo
+	push_hook testhookrepo master bin/hello
+	push_hook testrepo master config.env
+
+	run ssh_command "run testrepo hello World"
+	[ $status -eq 0 ]
+	echo ${output} | grep -q "Hello World"
+	echo ${output} | grep -q "From testrepo"
+}
+
 
 @test "Run script from hook dir - not found" {
 	run_container
 	ssh_command "mkrepo testrepo"
 
-	run ssh_command "run hello World"
+	run ssh_command "run testrepo hello World"
 	[ $status -eq 1 ]
 }


### PR DESCRIPTION
This is a unit test fallacy: usually HOOK_REPO isn't defined at launch
time, it's coded into a 'config.env' file that lives inside the hosted
repo.

Make sure the host repo's name is forwarded (via ENVIRONMENT env var) to
client script.