### PR TITLE
WEBOPS-424: path normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ services, server provisioning, etc.
 4. Setup Git-Deploy repo for each environment this deploy server can manage.
 
     ```bash
-    ssh git@ci.someserver.com mkrepo staging
+    ssh git@ci.someserver.com mkrepo staging.git
    ```
 
 ## Usage ##

--- a/bin/run
+++ b/bin/run
@@ -2,10 +2,10 @@
 
 source ~/.profile
 
-export ENVIRONMENT=$1
+export ENVIRONMENT=$(echo $1 | sed 's/\.git$//')
 CMD=$2
 
-cd /git/${ENVIRONMENT}
+cd /git/${ENVIRONMENT}.git
 git ls-tree --name-only -r master | grep -Fx config.env 2>&1 > /dev/null
 if [ $? -eq 0 ]; then
 	source <(git cat-file blob master:config.env)

--- a/test/test.bats
+++ b/test/test.bats
@@ -426,7 +426,7 @@ ${lines[1]}
 @test "Run script from hook dir" {
 	run_container
 	ssh_command "mkrepo testhookrepo"
-	ssh_command "mkrepo testrepo"
+	ssh_command "mkrepo testrepo.git"
 	clone_repo testhookrepo
 	clone_repo testrepo
 	destroy_container
@@ -441,13 +441,13 @@ ${lines[1]}
 @test "Run script from hook dir - config.env" {
 	run_container
 	ssh_command "mkrepo testhookrepo"
-	ssh_command "mkrepo testrepo"
+	ssh_command "mkrepo testrepo.git"
 	clone_repo testhookrepo
 	clone_repo testrepo
 	push_hook testhookrepo master bin/hello
 	push_hook testrepo master config.env
 
-	run ssh_command "run testrepo hello World"
+	run ssh_command "run testrepo.git hello World"
 	[ $status -eq 0 ]
 	echo ${output} | grep -q "Hello World"
 	echo ${output} | grep -q "From testrepo"
@@ -456,7 +456,7 @@ ${lines[1]}
 
 @test "Run script from hook dir - not found" {
 	run_container
-	ssh_command "mkrepo testrepo"
+	ssh_command "mkrepo testrepo.git"
 
 	run ssh_command "run testrepo hello World"
 	[ $status -eq 1 ]


### PR DESCRIPTION
By convention, environment names are `${ENVIRONMENT}.git`.

Rework the `run` command to embrace this convention (since it's
favourable to making the user type `.git` for every command).