### PR TITLE
WEBOPS-610: don't fetch every "run"

### DIFF
--- a/bin/hookpull
+++ b/bin/hookpull
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+source ~/.profile
+
+export ENVIRONMENT=$(echo $1 | sed 's/\.git$//')
+
+cd /git/${ENVIRONMENT}.git
+git ls-tree --name-only -r master | grep -Fx config.env 2>&1 > /dev/null
+if [ $? -eq 0 ]; then
+	source <(git cat-file blob master:config.env)
+fi
+
+if [ ! -z "$HOOK_REPO" ]; then
+	hook_dir="/git/hooks"
+	if [ ! -d "$hook_dir" ]; then
+		mkdir -p $hook_dir
+		git clone $HOOK_REPO $hook_dir
+	fi
+	git \
+		--git-dir="$hook_dir/.git" \
+		--work-tree="$hook_dir" \
+		fetch --all
+	if [ ! -z "$HOOK_REPO_REF" ]; then
+		git \
+			--git-dir="$hook_dir/.git" \
+			--work-tree="$hook_dir" \
+			reset --hard origin/$HOOK_REPO_REF
+	else
+		git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" pull
+	fi
+	if [ "$HOOK_REPO_VERIFY" = true ]; then
+		sign_status=$( git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" log --show-signature --pretty="%G?" -1 HEAD | tail -n1 )
+		if [ "$sign_status" != "G" ]; then
+			echo "Latest commit in $HOOK_REPO is not signed by a known key"
+			exit 1
+		fi
+	fi
+fi

--- a/bin/run
+++ b/bin/run
@@ -13,29 +13,6 @@ fi
 
 if [ ! -z "$HOOK_REPO" ]; then
 	hook_dir="/git/hooks"
-	if [ ! -d "$hook_dir" ]; then
-		mkdir -p $hook_dir
-		git clone $HOOK_REPO $hook_dir
-	fi
-	git \
-		--git-dir="$hook_dir/.git" \
-		--work-tree="$hook_dir" \
-		fetch --all
-	if [ ! -z "$HOOK_REPO_REF" ]; then
-		git \
-			--git-dir="$hook_dir/.git" \
-			--work-tree="$hook_dir" \
-			reset --hard origin/$HOOK_REPO_REF
-	else
-		git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" pull
-	fi
-	if [ "$HOOK_REPO_VERIFY" = true ]; then
-		sign_status=$( git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" log --show-signature --pretty="%G?" -1 HEAD | tail -n1 )
-		if [ "$sign_status" != "G" ]; then
-			echo "Latest commit in $HOOK_REPO is not signed by a known key"
-			exit 1
-		fi
-	fi
 else
 	hook_dir="hooks"
 fi

--- a/test/test.bats
+++ b/test/test.bats
@@ -433,6 +433,7 @@ ${lines[1]}
 	run_container /git/testhookrepo
 	push_hook testhookrepo master bin/hello
 
+	ssh_command "hookpull testrepo"
 	run ssh_command "run testrepo hello World"
 	[ $status -eq 0 ]
 	echo ${output} | grep -q "Hello World"
@@ -447,16 +448,30 @@ ${lines[1]}
 	push_hook testhookrepo master bin/hello
 	push_hook testrepo master config.env
 
+	# Pull isn't required as the push to "testrepo" already pulled.
 	run ssh_command "run testrepo.git hello World"
 	[ $status -eq 0 ]
 	echo ${output} | grep -q "Hello World"
 	echo ${output} | grep -q "From testrepo"
 }
 
-
 @test "Run script from hook dir - not found" {
 	run_container
 	ssh_command "mkrepo testrepo.git"
+
+	run ssh_command "run testrepo hello World"
+	[ $status -eq 1 ]
+}
+
+@test "Run script from hook dir - no pull" {
+	run_container
+	ssh_command "mkrepo testhookrepo"
+	ssh_command "mkrepo testrepo.git"
+	clone_repo testhookrepo
+	clone_repo testrepo
+	destroy_container
+	run_container /git/testhookrepo
+	push_hook testhookrepo master bin/hello
 
 	run ssh_command "run testrepo hello World"
 	[ $status -eq 1 ]


### PR DESCRIPTION
Split the HOOK_REPO integration from "run" to a standalone "hookpull"
command. This lets "run" run faster.

This makes the existing test fail (copy/paste to confirm that), but a
"hookpull" fixes it.