### PR TITLE
Retry backup in case duplicity is busy

### DIFF
--- a/bin/backup
+++ b/bin/backup
@@ -33,6 +33,7 @@ function run()
 	duplicity $FULL $DEBUG_ARGS --exclude="/git/.cache" --allow-source-mismatch /git/ $DEST
 }
 
+retries=0
 function backup()
 {
 	try
@@ -40,6 +41,10 @@ function backup()
 		run || throw 100
 	)
 	catch || (
+		retries=$((retries + 1))
+		if (( retries > 6 )); then
+			throw $ex_code
+		fi
 		sleep 5
 		backup		
 	)

--- a/bin/backup
+++ b/bin/backup
@@ -2,6 +2,24 @@
 
 source ~/.profile
 
+function try()
+{
+	[[ $- = *e* ]]; SAVED_OPT_E=$?
+	set +e
+}
+function throw()
+{
+	exit $1
+}
+function catch()
+{
+	export ex_code=$?
+	(( $SAVED_OPT_E )) && set +e
+	return $ex_code
+}
+
+
+
 if [ "$1" = "full" ]; then
 	FULL='full'
 fi
@@ -10,7 +28,24 @@ if [ "$DEBUG" = true ]; then
 	DEBUG_ARGS="-v9"
 fi
 
-duplicity $FULL $DEBUG_ARGS --exclude="/git/.cache" --allow-source-mismatch /git/ $DEST
+function run()
+{
+	duplicity $FULL $DEBUG_ARGS --exclude="/git/.cache" --allow-source-mismatch /git/ $DEST
+}
+
+function backup()
+{
+	try
+	(
+		run || throw 100
+	)
+	catch || (
+		sleep 5
+		backup		
+	)
+}
+
+backup
 
 if [ "$FULL" = "full" ]; then
 	duplicity remove-all-but-n-full 1 $DEST --force


### PR DESCRIPTION
Since we added the [full-backup.timer](https://github.com/pebble/git-deploy/blob/master/full-backup.timer) we haven't been running into this problem as much anymore, as `duplicity` only takes about a second. This just makes sure that if we run into two duplicities running simultaneously we implement a retry that makes some kind of sense.