### PR TITLE
rewrite post-receive to properly proxy stdin to child hook

### DIFF
--- a/base-hooks/helpers.sh
+++ b/base-hooks/helpers.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+get_hook_dir(){
+
+	if [ ! -z "$HOOK_REPO" ]; then
+		if [ ! -z "$ENVIRONMENT" ]; then
+			hook_dir="/git/${ENVIRONMENT}_hooks"
+		else
+			hook_dir="/git/hooks"
+		fi
+		if [ ! -d "$hook_dir" ]; then
+			mkdir -p "$hook_dir"
+			git clone "$HOOK_REPO" "$hook_dir" >/dev/null 2>&1
+		fi
+		git \
+			--git-dir="$hook_dir/.git" \
+			--work-tree="$hook_dir" \
+			fetch --all >/dev/null 2>&1
+		if [ ! -z "$HOOK_REPO_REF" ]; then
+			git \
+				--git-dir="$hook_dir/.git" \
+				--work-tree="$hook_dir" \
+				reset --hard "origin/$HOOK_REPO_REF" >/dev/null 2>&1
+		else
+			git \
+				--git-dir="$hook_dir/.git" \
+				--work-tree="$hook_dir" \
+				pull >/dev/null 2>&1
+		fi
+		if [ "$HOOK_REPO_VERIFY" = true ]; then
+			sign_status=$( git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" log --show-signature --pretty="%G?" -1 HEAD | tail -n1 )
+			if [ "$sign_status" != "G" ]; then
+				echo "Latest commit in $HOOK_REPO is not signed by a known key"
+				exit 1
+			fi
+		fi
+	else
+		hook_dir='hooks'
+	fi
+	export HOOK_DIR=$hook_dir
+}
+
+setup_env(){
+	ref=${1-master}
+	dir=$2
+	source ~/.profile
+	set -o pipefail
+	unset GIT_DIR
+	if [ ! -z "$env" ]; then
+		cd "$dir"
+	else
+		cd ..
+	fi
+	env -i git reset --hard
+	if git ls-tree --name-only -r "$ref" 2>&1 | grep -qFx config.env; then
+		# shellcheck disable=SC1090
+		source <(git cat-file blob "$ref:config.env")
+	fi
+	get_hook_dir
+}

--- a/base-hooks/helpers.sh
+++ b/base-hooks/helpers.sh
@@ -46,7 +46,7 @@ setup_env(){
 	source ~/.profile
 	set -o pipefail
 	unset GIT_DIR
-	if [ ! -z "$env" ]; then
+	if [ ! -z "$dir" ]; then
 		cd "$dir"
 	else
 		cd ..

--- a/base-hooks/post-receive
+++ b/base-hooks/post-receive
@@ -1,56 +1,21 @@
 #!/bin/bash
 
-source ~/.profile
-set -o pipefail
-
-unset GIT_DIR
-cd ..
-env -i git reset --hard
+source /opt/git-deploy/base-hooks/helpers.sh
 
 while read oldrev newrev refname; do
+	setup_env "$newrev"
 
-	# source config.env from incoming HEAD if it exists
-	if git ls-tree --name-only -r "$newrev" | grep -qFx config.env; then
-		source <(git cat-file blob "$newrev:config.env")
-	fi
-
-	# Update/use hooks from external repo if configured
-	if [ ! -z "$HOOK_REPO" ]; then
-		if [ ! -z "$ENVIRONMENT" ]; then
-			hook_dir="/git/${ENVIRONMENT}_hooks"
+	if [ -f "$HOOK_DIR/post-receive" ]; then
+		if [ "${CAPTURE_OUTPUT}" == "true" ]; then
+			echo "$oldrev" "$newrev" "$refname" \
+				| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" \
+					bash "$HOOK_DIR/post-receive" 2>&1 \
+				| tee /var/log/git-deploy/hooks.log
 		else
-			hook_dir="/git/hooks"
+			echo "$oldrev" "$newrev" "$refname" \
+				| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" \
+					bash "$HOOK_DIR/post-receive"
 		fi
-		
-		if [ ! -d "$hook_dir" ]; then
-			mkdir -p "$hook_dir"
-			git clone "$HOOK_REPO" "$hook_dir"
-		fi
-		git \
-			--git-dir="$hook_dir/.git" \
-			--work-tree="$hook_dir" \
-			fetch --all
-		if [ ! -z "$HOOK_REPO_REF" ]; then
-			git \
-				--git-dir="$hook_dir/.git" \
-				--work-tree="$hook_dir" \
-				reset --hard "origin/$HOOK_REPO_REF"
-		else
-			git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" pull
-		fi
-	else
-		hook_dir="hooks"
-	fi
-
-	if [ "${CAPTURE_OUTPUT}" == "true" ]; then
-		echo "$oldrev" "$newrev" "$refname" \
-			| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" \
-				bash "$hook_dir/post-receive" 2>&1 \
-			| tee /var/log/git-deploy/hooks.log
-	else
-		echo "$oldrev" "$newrev" "$refname" \
-			| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" \
-				bash $hook_dir/post-receive
 	fi
 
 	/git/git-shell-commands/backup

--- a/base-hooks/post-receive
+++ b/base-hooks/post-receive
@@ -10,8 +10,7 @@ env -i git reset --hard
 while read oldrev newrev refname; do
 
 	# source config.env from incoming HEAD if it exists
-	git ls-tree --name-only -r "$newrev" | grep -Fx config.env >> /dev/null
-	if [ $? -eq 0 ]; then
+	if git ls-tree --name-only -r "$newrev" | grep -qFx config.env; then
 		source <(git cat-file blob "$newrev:config.env")
 	fi
 

--- a/base-hooks/post-receive
+++ b/base-hooks/post-receive
@@ -5,13 +5,14 @@ set -o pipefail
 
 unset GIT_DIR
 cd ..
+env -i git reset --hard
 
 while read oldrev newrev refname; do
 
 	# source config.env from incoming HEAD if it exists
-	git ls-tree --name-only -r $newrev | grep -Fx config.env >> /dev/null
+	git ls-tree --name-only -r "$newrev" | grep -Fx config.env >> /dev/null
 	if [ $? -eq 0 ]; then
-		source <(git cat-file blob $newrev:config.env)
+		source <(git cat-file blob "$newrev:config.env")
 	fi
 
 	# Update/use hooks from external repo if configured
@@ -21,11 +22,38 @@ while read oldrev newrev refname; do
 		else
 			hook_dir="/git/hooks"
 		fi
+		
+		if [ ! -d "$hook_dir" ]; then
+			mkdir -p "$hook_dir"
+			git clone "$HOOK_REPO" "$hook_dir"
+		fi
+		git \
+			--git-dir="$hook_dir/.git" \
+			--work-tree="$hook_dir" \
+			fetch --all
+		if [ ! -z "$HOOK_REPO_REF" ]; then
+			git \
+				--git-dir="$hook_dir/.git" \
+				--work-tree="$hook_dir" \
+				reset --hard "origin/$HOOK_REPO_REF"
+		else
+			git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" pull
+		fi
 	else
 		hook_dir="hooks"
 	fi
 
-	[ ! -f "$hook_dir/post-receive" ] || bash $hook_dir/post-receive | tee /var/log/git-deploy/hooks.log
+	if [ "${CAPTURE_OUTPUT}" == "true" ]; then
+		echo "$oldrev" "$newrev" "$refname" \
+			| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" \
+				bash "$hook_dir/post-receive" 2>&1 \
+			| tee /var/log/git-deploy/hooks.log
+	else
+		echo "$oldrev" "$newrev" "$refname" \
+			| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" \
+				bash $hook_dir/post-receive
+	fi
+
 	/git/git-shell-commands/backup
 
 done

--- a/base-hooks/post-receive
+++ b/base-hooks/post-receive
@@ -4,7 +4,6 @@ source /opt/git-deploy/base-hooks/helpers.sh
 
 while read oldrev newrev refname; do
 	setup_env "$newrev"
-
 	if [ -f "$HOOK_DIR/post-receive" ]; then
 		if [ "${CAPTURE_OUTPUT}" == "true" ]; then
 			echo "$oldrev" "$newrev" "$refname" \
@@ -17,7 +16,5 @@ while read oldrev newrev refname; do
 					bash "$HOOK_DIR/post-receive"
 		fi
 	fi
-
 	/git/git-shell-commands/backup
-
 done

--- a/base-hooks/pre-receive
+++ b/base-hooks/pre-receive
@@ -1,57 +1,12 @@
 #!/bin/bash
 
-source ~/.profile
-set -o pipefail
-
-unset GIT_DIR
-cd ..
-env -i git reset --hard
+source /opt/git-deploy/base-hooks/helpers.sh
 
 while read oldrev newrev refname; do
 
-	# source config.env from incoming HEAD if it exists
-	git ls-tree --name-only -r $newrev | grep -Fx config.env >> /dev/null
-	if [ $? -eq 0 ]; then
-		source <(git cat-file blob $newrev:config.env)
-	fi
+	setup_env "$newrev"
 
-	# Update/use hooks from external repo if configured
-	if [ ! -z "$HOOK_REPO" ]; then
-		if [ ! -z "$ENVIRONMENT" ]; then
-			hook_dir="/git/${ENVIRONMENT}_hooks"
-		else
-			hook_dir="/git/hooks"
-		fi
-		
-		if [ ! -d "$hook_dir" ]; then
-			mkdir -p $hook_dir
-			git clone $HOOK_REPO $hook_dir
-		fi
-		git \
-			--git-dir="$hook_dir/.git" \
-			--work-tree="$hook_dir" \
-			fetch --all
-		if [ ! -z "$HOOK_REPO_REF" ]; then
-			git \
-				--git-dir="$hook_dir/.git" \
-				--work-tree="$hook_dir" \
-				reset --hard origin/$HOOK_REPO_REF
-		else
-			git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" pull
-		fi
-		
-		if [ "$HOOK_REPO_VERIFY" = true ]; then
-			sign_status=$( git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" log --show-signature --pretty="%G?" -1 HEAD | tail -n1 )
-			if [ "$sign_status" != "G" ]; then
-				echo "Latest commit in $HOOK_REPO is not signed by a known key"
-				exit 1
-			fi
-		fi
-	else
-		hook_dir="hooks"
-	fi
-
-	if [ -f "$hook_dir/pre-receive" ]; then
+	if [ -f "$HOOK_DIR/pre-receive" ]; then
 		(
 			if ! flock -nx 201; then
 				echo "Unable to acquire local deploy lock, another git push is in progress"
@@ -59,12 +14,12 @@ while read oldrev newrev refname; do
 			fi
 
 			if [ "${CAPTURE_OUTPUT}" == "true" ]; then
-				echo $oldrev $newrev $refname \
-					| timeout -k ${DEPLOY_TIMEOUT_KILL} ${DEPLOY_TIMEOUT_TERM} bash $hook_dir/pre-receive 2>&1 \
+				echo "$oldrev" "$newrev" "$refname" \
+					| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" bash "$HOOK_DIR/pre-receive" 2>&1 \
 					| tee /var/log/git-deploy/hooks.log
 			else
-				echo $oldrev $newrev $refname \
-					| timeout -k ${DEPLOY_TIMEOUT_KILL} ${DEPLOY_TIMEOUT_TERM} bash $hook_dir/pre-receive
+				echo "$oldrev" "$newrev" "$refname" \
+					| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" bash "$HOOK_DIR/pre-receive"
 			fi
 		) 201>pre_receive_lock
 	fi

--- a/base-hooks/pre-receive
+++ b/base-hooks/pre-receive
@@ -5,19 +5,13 @@ source /opt/git-deploy/base-hooks/helpers.sh
 while read oldrev newrev refname; do
 	setup_env "$newrev"
 	if [ -f "$HOOK_DIR/pre-receive" ]; then
-		(
-			if ! flock -nx 201; then
-				echo "Unable to acquire local deploy lock, another git push is in progress"
-				exit 1
-			fi
-			if [ "${CAPTURE_OUTPUT}" == "true" ]; then
-				echo "$oldrev" "$newrev" "$refname" \
-					| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" bash "$HOOK_DIR/pre-receive" 2>&1 \
-					| tee /var/log/git-deploy/hooks.log
-			else
-				echo "$oldrev" "$newrev" "$refname" \
-					| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" bash "$HOOK_DIR/pre-receive"
-			fi
-		) 201>pre_receive_lock
+		if [ "${CAPTURE_OUTPUT}" == "true" ]; then
+			echo "$oldrev" "$newrev" "$refname" \
+				| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" bash "$HOOK_DIR/pre-receive" 2>&1 \
+				| tee /var/log/git-deploy/hooks.log
+		else
+			echo "$oldrev" "$newrev" "$refname" \
+				| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" bash "$HOOK_DIR/pre-receive"
+		fi
 	fi
 done

--- a/base-hooks/pre-receive
+++ b/base-hooks/pre-receive
@@ -3,16 +3,13 @@
 source /opt/git-deploy/base-hooks/helpers.sh
 
 while read oldrev newrev refname; do
-
 	setup_env "$newrev"
-
 	if [ -f "$HOOK_DIR/pre-receive" ]; then
 		(
 			if ! flock -nx 201; then
 				echo "Unable to acquire local deploy lock, another git push is in progress"
 				exit 1
 			fi
-
 			if [ "${CAPTURE_OUTPUT}" == "true" ]; then
 				echo "$oldrev" "$newrev" "$refname" \
 					| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" bash "$HOOK_DIR/pre-receive" 2>&1 \
@@ -23,5 +20,4 @@ while read oldrev newrev refname; do
 			fi
 		) 201>pre_receive_lock
 	fi
-
 done

--- a/base-hooks/pre-receive
+++ b/base-hooks/pre-receive
@@ -5,13 +5,19 @@ source /opt/git-deploy/base-hooks/helpers.sh
 while read oldrev newrev refname; do
 	setup_env "$newrev"
 	if [ -f "$HOOK_DIR/pre-receive" ]; then
-		if [ "${CAPTURE_OUTPUT}" == "true" ]; then
-			echo "$oldrev" "$newrev" "$refname" \
-				| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" bash "$HOOK_DIR/pre-receive" 2>&1 \
-				| tee /var/log/git-deploy/hooks.log
-		else
-			echo "$oldrev" "$newrev" "$refname" \
-				| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" bash "$HOOK_DIR/pre-receive"
-		fi
+		(
+			if ! flock -nx 201; then
+				echo "Unable to acquire local deploy lock, another git push is in progress"
+				exit 1
+			fi
+			if [ "${CAPTURE_OUTPUT}" == "true" ]; then
+				echo "$oldrev" "$newrev" "$refname" \
+					| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" bash "$HOOK_DIR/pre-receive" 2>&1 \
+					| tee /var/log/git-deploy/hooks.log
+			else
+				echo "$oldrev" "$newrev" "$refname" \
+					| timeout -k "$DEPLOY_TIMEOUT_KILL" "$DEPLOY_TIMEOUT_TERM" bash "$HOOK_DIR/pre-receive"
+			fi
+		) 201>pre_receive_lock
 	fi
 done

--- a/base-hooks/update
+++ b/base-hooks/update
@@ -6,13 +6,11 @@ set -o pipefail
 unset GIT_DIR
 cd ..
 
-refname="$1"
-oldrev="$2"
 newrev="$3"
 
 # source config.env from incoming HEAD if it exists
-git ls-tree --name-only -r $newrev | grep -Fx config.env >> /dev/null
-if [ $? -eq 0 ]; then
+if git ls-tree --name-only -r $newrev 2>&1 | grep -qFx config.env; then
+	# shellcheck disable=SC1090
 	source <(git cat-file blob $newrev:config.env)
 fi
 

--- a/bin/hookpull
+++ b/bin/hookpull
@@ -1,36 +1,42 @@
 #!/bin/bash
 
+# shellcheck disable=SC1090
 source ~/.profile
 
-export ENVIRONMENT=$(echo $1 | sed 's/\.git$//')
+environment=${1/.git/}
+hook_branch=${2-master}
 
-cd /git/${ENVIRONMENT}.git
-git ls-tree --name-only -r master | grep -Fx config.env 2>&1 > /dev/null
-if [ $? -eq 0 ]; then
+cd "/git/${environment}.git" || exit 1
+if git ls-tree --name-only -r "$hook_branch" | \
+  grep -qFx config.env >/dev/null 2>&1; then
+	# shellcheck disable=SC1090
 	source <(git cat-file blob master:config.env)
 fi
 
 if [ ! -z "$HOOK_REPO" ]; then
-	if [ ! -z "$ENVIRONMENT" ]; then
-		hook_dir="/git/${ENVIRONMENT}_hooks"
+	if [ ! -z "$environment" ]; then
+		hook_dir="/git/${environment}_hooks"
 	else
 		hook_dir="/git/hooks"
 	fi
 	if [ ! -d "$hook_dir" ]; then
 		mkdir -p $hook_dir
-		git clone $HOOK_REPO $hook_dir
+		git clone "$HOOK_REPO" "$hook_dir" >/dev/null 2>&1
 	fi
 	git \
 		--git-dir="$hook_dir/.git" \
 		--work-tree="$hook_dir" \
-		fetch --all
+		fetch --all >/dev/null 2>&1
 	if [ ! -z "$HOOK_REPO_REF" ]; then
 		git \
 			--git-dir="$hook_dir/.git" \
 			--work-tree="$hook_dir" \
-			reset --hard origin/$HOOK_REPO_REF
+			reset --hard "origin/$HOOK_REPO_REF" >/dev/null 2>&1
 	else
-		git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" pull
+		git \
+			--git-dir="$hook_dir/.git" \
+			--work-tree="$hook_dir" \
+			pull >/dev/null 2>&1
 	fi
 	if [ "$HOOK_REPO_VERIFY" = true ]; then
 		sign_status=$( git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" log --show-signature --pretty="%G?" -1 HEAD | tail -n1 )
@@ -40,3 +46,5 @@ if [ ! -z "$HOOK_REPO" ]; then
 		fi
 	fi
 fi
+
+echo -n $hook_dir

--- a/bin/hookpull
+++ b/bin/hookpull
@@ -1,49 +1,7 @@
 #!/bin/bash
 
-# shellcheck disable=SC1090
-source ~/.profile
+source /opt/git-deploy/base-hooks/helpers.sh
 
-environment=${1/.git//}
-hook_branch=${2-master}
+export ENVIRONMENT=${1/.git$//}
 
-cd "/git/${environment}" || exit 1
-if git ls-tree --name-only -r "$hook_branch" 2>&1 | grep -qFx config.env; then
-	# shellcheck disable=SC1090
-	source <(git cat-file blob master:config.env)
-fi
-
-if [ ! -z "$HOOK_REPO" ]; then
-	if [ ! -z "$environment" ]; then
-		hook_dir="/git/${environment}_hooks"
-	else
-		hook_dir="/git/hooks"
-	fi
-	if [ ! -d "$hook_dir" ]; then
-		mkdir -p $hook_dir
-		git clone "$HOOK_REPO" "$hook_dir" >/dev/null 2>&1
-	fi
-	git \
-		--git-dir="$hook_dir/.git" \
-		--work-tree="$hook_dir" \
-		fetch --all >/dev/null 2>&1
-	if [ ! -z "$HOOK_REPO_REF" ]; then
-		git \
-			--git-dir="$hook_dir/.git" \
-			--work-tree="$hook_dir" \
-			reset --hard "origin/$HOOK_REPO_REF" >/dev/null 2>&1
-	else
-		git \
-			--git-dir="$hook_dir/.git" \
-			--work-tree="$hook_dir" \
-			pull >/dev/null 2>&1
-	fi
-	if [ "$HOOK_REPO_VERIFY" = true ]; then
-		sign_status=$( git --git-dir="$hook_dir/.git" --work-tree="$hook_dir" log --show-signature --pretty="%G?" -1 HEAD | tail -n1 )
-		if [ "$sign_status" != "G" ]; then
-			echo "Latest commit in $HOOK_REPO is not signed by a known key"
-			exit 1
-		fi
-	fi
-fi
-
-echo -n $hook_dir
+setup_env master "/git/$ENVIRONMENT"

--- a/bin/hookpull
+++ b/bin/hookpull
@@ -3,12 +3,11 @@
 # shellcheck disable=SC1090
 source ~/.profile
 
-environment=${1/.git/}
+environment=${1/.git//}
 hook_branch=${2-master}
 
-cd "/git/${environment}.git" || exit 1
-if git ls-tree --name-only -r "$hook_branch" | \
-  grep -qFx config.env >/dev/null 2>&1; then
+cd "/git/${environment}" || exit 1
+if git ls-tree --name-only -r "$hook_branch" 2>&1 | grep -qFx config.env; then
 	# shellcheck disable=SC1090
 	source <(git cat-file blob master:config.env)
 fi

--- a/bin/hookpull
+++ b/bin/hookpull
@@ -4,4 +4,4 @@ source /opt/git-deploy/base-hooks/helpers.sh
 
 export ENVIRONMENT=${1/.git$//}
 
-setup_env master "/git/$ENVIRONMENT"
+setup_env master "/git/${ENVIRONMENT}.git"


### PR DESCRIPTION
post-receive hooks are supposed to mostly behave the same way as pre-receive and get the same stdin. Updated out post-receive to mirror logic of pre-receive with slight deviations where appropriate.

Tested with multiple deploys by manually injecting into base-hooks of development environment.