### PR TITLE
config-selectable debug mode

### DIFF
--- a/base-hooks/helpers.sh
+++ b/base-hooks/helpers.sh
@@ -56,5 +56,10 @@ setup_env(){
 		# shellcheck disable=SC1090
 		source <(git cat-file blob "$ref:config.env")
 	fi
+	if [ "$DEBUG" == "true" ]; then
+		export CAPTURE_OUTPUT="false"
+		env
+		set -x
+	fi
 	get_hook_dir
 }


### PR DESCRIPTION
I end up doing stuff like this by hand a lot with a series of commits and manually monkeypatching the server.

Figured I might as well make it a feature to save noise.

Note: I explicitly disable external logging in DEBUG mode so as not to log secrets.

Tested in develop for real-world debugging.