### PR TITLE
WEBOPS-820: disallow internal commands

### DIFF
--- a/bin/login
+++ b/bin/login
@@ -2,4 +2,10 @@
 
 export CURRENT_USER=$1
 
+if [[ $SSH_ORIGINAL_COMMAND == login* ]]; then
+	exit 1
+elif [[ $SSH_ORIGINAL_COMMAND == restore* ]]; then
+	exit 1
+fi
+
 exec git-shell -c "$SSH_ORIGINAL_COMMAND"

--- a/test/test.bats
+++ b/test/test.bats
@@ -343,7 +343,7 @@ ${lines[1]}
 	echo ${output} | grep -q "Rejecting badfile"
 }
 
-@test "ssh key validation fails with a bad key" {
+@test "SSH key validation fails with a bad key" {
 	key=$(cat test-keys/test-sshkey.pub | cut -b 512-)
 	command="ssh-key badkey '${key}'"
 	run ssh_command "$command"
@@ -473,5 +473,10 @@ ssh_command "hookpull testrepo"
 	push_hook testhookrepo master bin/hello
 
 	run ssh_command "run testrepo hello World"
+	[ $status -eq 1 ]
+}
+
+@test "Avoid 'login' fork bomb" {
+	run ssh_command "login"
 	[ $status -eq 1 ]
 }


### PR DESCRIPTION
Failing test case explains it best: you can `ssh git@localhost login`:
login calls login calls login, kaboom.

Removing `login` from the path would be _ideal_, but git-shell can't
invoke it there. This isn't worth leaving the cozy sandbox that
git-shell provides.